### PR TITLE
Fix the problem with YAML.dump

### DIFF
--- a/lib/activeuuid/uuid.rb
+++ b/lib/activeuuid/uuid.rb
@@ -25,6 +25,11 @@ module UUIDTools
       hexdigest.upcase
     end
 
+    # YAML.dump
+    def encode_with coder
+      coder.represent_scalar nil, self.to_s
+    end
+
     def ==(other)
       self.to_s == other.to_s
     end


### PR DESCRIPTION
When UUID is used in `audited`, it will be dumped as Ruby Binary object,
which is really bad.