### PR TITLE
Rails4.1 no need to parse a UUID

### DIFF
--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -183,6 +183,7 @@ module ActiveUUID
       included do
         def records_for_with_conversion(ids)
           records_for_without_conversion(ids).each do |record|
+            next if record[association_key_name].is_a?(UUIDTools::UUID)
             record[association_key_name] = UUIDTools::UUID.parse_raw(record[association_key_name])
           end
         end

--- a/lib/activeuuid/version.rb
+++ b/lib/activeuuid/version.rb
@@ -1,3 +1,3 @@
 module Activeuuid
-  VERSION = "0.5.2.b40"
+  VERSION = "0.5.3.b40"
 end


### PR DESCRIPTION
as string when it is already instantiated as a UUID
avoids the following issue in 4.1

```
     TypeError:
       Expected String, got UUIDTools::UUID instead.
```